### PR TITLE
strip single quotes from message subject

### DIFF
--- a/mailapp-to-todoist.scpt
+++ b/mailapp-to-todoist.scpt
@@ -5,7 +5,8 @@ tell application "Mail"
 	set todoistToken to (system attribute "todoistToken")
 	set mailMessages to the selection	
 	repeat with theMessage in the mailMessages
-		set messageSubject to the subject of the theMessage
+		-- strip single quotes - TODO, figure out how to gracefully escape them
+		set messageSubject to my replace_chars(the subject of the theMessage, "'", "")
 		copy messageSubject to end of messageList
 		set messageUrl to "message://%3c" & theMessage's message id & "%3e"
 				
@@ -19,3 +20,12 @@ tell application "Mail"
 end tell
 return messageList
 end run
+
+on replace_chars(this_text, search_string, replacement_string)
+	set AppleScript's text item delimiters to the search_string
+	set the item_list to every text item of this_text
+	set AppleScript's text item delimiters to the replacement_string
+	set this_text to the item_list as string
+	set AppleScript's text item delimiters to ""
+	return this_text
+end replace_chars


### PR DESCRIPTION
Mail messages with a single quote in the subject would break the script - in theory, we should be able to escape those but in practice it has me tearing my hair out trying to get it right, so just stripping single quotes from the subject when creating the task.